### PR TITLE
Time mejora del formato

### DIFF
--- a/main/cmd/time.js
+++ b/main/cmd/time.js
@@ -7,19 +7,47 @@ function def(cmd, user, users, bot, channelID, evt) {
 			"fields": [
 				{
 					"name": ":flag_ve: Venezuela",
-					"value": Fecha.toLocaleString("es-VE", {timeZone: "America/Caracas"}) + "VE"
+					"value": Fecha.toLocaleString("en-US", {
+						day: "2-digit",
+						month: "2-digit",
+						year: "numeric",
+						hour: "2-digit",
+						minute: "2-digit",
+						timeZone: "America/Caracas"
+					})
 				},
 				{
 					'name': ':flag_co: Colombia',
-					"value": Fecha.toLocaleString("en-US", {timeZone: "America/Bogota"}) + "US"
+					"value": Fecha.toLocaleString("en-US", {
+						day: "2-digit",
+						month: "2-digit",
+						year: "numeric",
+						hour: "2-digit",
+						minute: "2-digit",
+						timeZone: "America/Bogota"
+					})
 				},
 				{
 					'name': ':flag_cl: Chile',
-					"value": Fecha.toLocaleString("en-GB", {timeZone: "America/Santiago"}) + "GB"
+					"value": Fecha.toLocaleString("en-US", {
+						day: "2-digit",
+						month: "2-digit",
+						year: "numeric",
+						hour: "2-digit",
+						minute: "2-digit",
+						timeZone: "America/Santiago"
+					})
 				},
 				{
 					'name': ':flag_do: República Dominicana',
-					"value": Fecha.toLocaleString("es-ES", {timeZone: "America/Santo_Domingo"})
+					"value": Fecha.toLocaleString("en-US", {
+						day: "2-digit",
+						month: "2-digit",
+						year: "numeric",
+						hour: "2-digit",
+						minute: "2-digit",
+						timeZone: "America/Santo_Domingo"
+					})
 				}
 			]
 		}


### PR DESCRIPTION
Agregada configuración

```json
{
	day: "2-digit",
	month: "2-digit",
	year: "numeric",
	hour: "2-digit",
	minute: "2-digit",
	timeZone: "America/Caracas"
}
```